### PR TITLE
Adjust auth position

### DIFF
--- a/app_api/routes/index.js
+++ b/app_api/routes/index.js
@@ -13,24 +13,24 @@ const ctrlAuth = require('../controllers/authentication');
 router
   .route('/locations')
   .get(ctrlLocations.locationsListByDistance)
-  .post(auth, ctrlLocations.locationsCreate);
+  .post(ctrlLocations.locationsCreate);
 
 router
   .route('/locations/:locationid')
   .get(ctrlLocations.locationsReadOne)
   .put(auth, ctrlLocations.locationsUpdateOne)
-  .delete(auth, ctrlLocations.locationsDeleteOne);
+  .delete(ctrlLocations.locationsDeleteOne);
 
 // reviews
 router
   .route('/locations/:locationid/reviews')
-  .post(ctrlReviews.reviewsCreate);
+  .post(auth, ctrlReviews.reviewsCreate);
 
 router
   .route('/locations/:locationid/reviews/:reviewid')
   .get(ctrlReviews.reviewsReadOne)
-  .put(ctrlReviews.reviewsUpdateOne)
-  .delete(ctrlReviews.reviewsDeleteOne);
+  .put(auth, ctrlReviews.reviewsUpdateOne)
+  .delete(auth, ctrlReviews.reviewsDeleteOne);
 
 router.post('/register', ctrlAuth.register);
 router.post('/login', ctrlAuth.login);

--- a/app_api/routes/index.js
+++ b/app_api/routes/index.js
@@ -18,7 +18,7 @@ router
 router
   .route('/locations/:locationid')
   .get(ctrlLocations.locationsReadOne)
-  .put(auth, ctrlLocations.locationsUpdateOne)
+  .put(ctrlLocations.locationsUpdateOne)
   .delete(ctrlLocations.locationsDeleteOne);
 
 // reviews


### PR DESCRIPTION
The auth should be placed in reviews rather than locations.
The get-mean book also put the auth in review routings rather than the location routings.
The issue caused the req.payload in app_api/controllers/reviews.js being undefined. I fixed the issue after I correct the file.